### PR TITLE
[ProtoDev] Disabled F3 ACRE2 module settings for auto-adding radios to units

### DIFF
--- a/Ph.VR/f/radios/acre2/acre2_settings.sqf
+++ b/Ph.VR/f/radios/acre2/acre2_settings.sqf
@@ -15,14 +15,17 @@ f_radios_settings_acre2_disableFrequencySplit = FALSE;
 // Set a list of units that get a short wave
 // if its nil, that means all units get a radio
 // empty array means that noone gets
-f_radios_settings_acre2_shortRange = ["ftl","ar","aar","rat","dm","gren","r","car","smg"];
+//f_radios_settings_acre2_shortRange = ["ftl","ar","aar","rat","dm","gren","r","car","smg"];
+f_radios_settings_acre2_shortRange = [];
 
 // Set the list of units that get a long range
-f_radios_settings_acre2_longRange = ["co", "dc","ftl","m", "mmgag","hmgag","matag","hatag", "mtrag","msamag","sp","vc", "pp","fwp", "eng", "engm", "uav", "fo", "div"];
+//f_radios_settings_acre2_longRange = ["co", "dc","ftl","m", "mmgag","hmgag","matag","hatag", "mtrag","msamag","sp","vc", "pp","fwp", "eng", "engm", "uav", "fo", "div"];
+f_radios_settings_acre2_longRange = [];
 
 // Unit types you want to give an extra long-range radio
 // E.G: ["co", "m"] would give the CO and all medics an extra long-range radios
-f_radios_settings_acre2_extraRadios = ["co","fo","vc","pp","fwp"];
+//f_radios_settings_acre2_extraRadios = ["co","fo","vc","pp","fwp"];
+f_radios_settings_acre2_extraRadios = [];
 
 // Standard Short
 f_radios_settings_acre2_standardSHRadio = "ACRE_PRC343";


### PR DESCRIPTION
Disabled F3 module settings for auto-adding radios to units based on loadout type. (Probably was broken anyway by new gear system)